### PR TITLE
Implementación de lógica para entornos de demo y producción en configuración de endpoints

### DIFF
--- a/src/Components/Popup/index.tsx
+++ b/src/Components/Popup/index.tsx
@@ -17,6 +17,7 @@ import { Btn, BtnSubmit } from "../Buttons";
 import { Capitalize } from "../../Utils";
 import CloseIcon from "@mui/icons-material/Close";
 import { IWorkRecord } from "../../interface";
+import { API_URLS } from "../../service/apiConfig";
 
 interface FormData {
   details: string;
@@ -57,7 +58,7 @@ export const Popup: React.FC<IPopup> = ({
   }, [open, reset]);
 
   const onSubmit: SubmitHandler<FormData> = async (data) => {
-    const URL_ENDPOINT = import.meta.env.VITE_WORKE_RECORDS_ADD_DETAILS;
+    const URL_ENDPOINT = API_URLS.WORK_RECORDS_ADD_DETAILS;
 
     const newDetails = {
       registerId: currentUser?.id,

--- a/src/Components/PopupProduct/index.tsx
+++ b/src/Components/PopupProduct/index.tsx
@@ -17,6 +17,7 @@ import { Btn, BtnMini } from "../Buttons";
 import CloseIcon from "@mui/icons-material/Close";
 import { useDispatch } from "react-redux";
 import { setUpdated } from "../../Store/Slices/updateSlice";
+import { API_URLS } from "../../service/apiConfig";
 
 interface IProduct {
   id: string;
@@ -57,7 +58,7 @@ export const PopupProduct: React.FC<PopupFormProps> = ({
       registerId: currentProduct.id,
       count: count,
     };
-    const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS_UPDATE_COUNT;
+    const URL_ENDPOINT = API_URLS.PRODUCTS_UPDATE_COUNT;
 
     setLoading(true);
     setTimeout(async () => {

--- a/src/Components/Table/TableService/index.tsx
+++ b/src/Components/Table/TableService/index.tsx
@@ -19,6 +19,7 @@ import { setUpdated } from "../../../Store/Slices/updateSlice";
 import { Loading } from "../../Loading";
 import { Popup } from "../../Popup";
 import { TimeTracker } from "../../TimeTracker";
+import { API_URLS } from "../../../service/apiConfig";
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   [`&.${tableCellClasses.head}`]: {
@@ -83,7 +84,7 @@ export const TableService: React.FC<TablesProps> = ({ title, data, reset }) => {
   const handleClose = () => setOpen(false);
 
   const onWorker = (personal: IPersonalData) => {
-    const URL_ENDPOINT = import.meta.env.VITE_WORKE_RECORDS_START;
+    const URL_ENDPOINT = API_URLS.WORK_RECORDS_START;
     const documents = {
       profile: {
         id: personal.id,
@@ -138,7 +139,8 @@ export const TableService: React.FC<TablesProps> = ({ title, data, reset }) => {
   };
 
   const offWorker = (personal: IPersonalData) => {
-    const URL_ENDPOINT = import.meta.env.VITE_WORKE_RECORDS_END;
+    const URL_ENDPOINT = API_URLS.WORK_RECORDS_END;
+
     const documents = {
       id: personal.id,
     };
@@ -190,7 +192,8 @@ export const TableService: React.FC<TablesProps> = ({ title, data, reset }) => {
   };
 
   const closeRecord = (record: IWorkRecord) => {
-    const URL_ENDPOINT = import.meta.env.VITE_WORKE_CLOSE_RECORDS;
+    const URL_ENDPOINT = API_URLS.WORK_CLOSE_RECORDS;
+
     const documents = {
       recordId: record.id,
       userId: record.profile.id,

--- a/src/Hooks/UseGetProducts/index.ts
+++ b/src/Hooks/UseGetProducts/index.ts
@@ -4,6 +4,7 @@ import axios from "../../service/httpService";
 import { useDispatch, useSelector } from "react-redux";
 import { setUpdated } from "../../Store/Slices/updateSlice";
 import { RootState } from "../../Store";
+import { API_URLS } from "../../service/apiConfig";
 
 interface UseProductsResult<T> {
   data: T[];
@@ -24,7 +25,7 @@ export const UseGetProducts = <T>(limit: number): UseProductsResult<T> => {
   const updated = useSelector((state: RootState) => state.update.updated);
   const dispatch = useDispatch();
 
-  const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS;
+  const URL_ENDPOINT = API_URLS.PRODUCTS;
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/Hooks/UseGetUsers/index.ts
+++ b/src/Hooks/UseGetUsers/index.ts
@@ -4,6 +4,7 @@ import axios from "../../service/httpService";
 import { useDispatch, useSelector } from "react-redux";
 import { setUpdated } from "../../Store/Slices/updateSlice";
 import { RootState } from "../../Store";
+import { API_URLS } from "../../service/apiConfig";
 
 interface UseUsersResult<T> {
   data: T[];
@@ -24,7 +25,7 @@ export const UseGetUsers = <T>(limit: number): UseUsersResult<T> => {
   const updated = useSelector((state: RootState) => state.update.updated);
   const dispatch = useDispatch();
 
-  const URL_ENDPOINT = import.meta.env.VITE_USER_ALL;
+  const URL_ENDPOINT = API_URLS.USER_ALL;
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/Hooks/UseGlobalLogs/index.ts
+++ b/src/Hooks/UseGlobalLogs/index.ts
@@ -4,6 +4,7 @@ import axios from "../../service/httpService";
 import { useDispatch, useSelector } from "react-redux";
 import { setUpdated } from "../../Store/Slices/updateSlice";
 import { RootState } from "../../Store";
+import { API_URLS } from "../../service/apiConfig";
 
 interface UseLogsResult<T> {
   data: T[];
@@ -27,8 +28,8 @@ export const UseGlobalLogs = <T>(limit: number): UseLogsResult<T> => {
   const updated = useSelector((state: RootState) => state.update.updated);
   const dispatch = useDispatch();
 
-  const MOSTHS = import.meta.env.VITE_GLOBAL_LOGS_MONTHS;
-  const ALL_LOGS = import.meta.env.VITE_GLOBAL_LOGS_ALL;
+  const MOSTHS = API_URLS.GLOBAL_LOGS_MONTHS;
+  const ALL_LOGS = API_URLS.GLOBAL_LOGS_ALL;
 
   const URL_ENDPOINT = searchTerm ? MOSTHS : ALL_LOGS;
 

--- a/src/Hooks/UseWorkHours/index.ts
+++ b/src/Hooks/UseWorkHours/index.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import axios from "../../service/httpService";
 
 import Swal from "sweetalert2";
+import { API_URLS } from "../../service/apiConfig";
 
 interface IUseWorkHours<T> {
   data: T[];
@@ -27,8 +28,8 @@ export const UseWorkHours = <T>(): IUseWorkHours<T> => {
 
   const limit = 4;
 
-  const MONTHS = import.meta.env.VITE_WORKE_HOURS_SEARCH_MONTHS;
-  const RECORDS = `${import.meta.env.VITE_WORKE_HOURS_ALL_RECORDS}/${userId}`;
+  const MONTHS = API_URLS.WORK_HOURS_SEARCH_MONTHS;
+  const RECORDS = `${API_URLS.WORK_HOURS_ALL_RECORDS}/${userId}`;
 
   const URL_ENDPOINT = searchTerm ? MONTHS : RECORDS;
 

--- a/src/Hooks/useAllDocuments/index.ts
+++ b/src/Hooks/useAllDocuments/index.ts
@@ -4,6 +4,7 @@ import axios from "../../service/httpService";
 import { useDispatch, useSelector } from "react-redux";
 import { setUpdated } from "../../Store/Slices/updateSlice";
 import { RootState } from "../../Store";
+import { API_URLS } from "../../service/apiConfig";
 
 interface IUseAllDocuments<T> {
   data: T[];
@@ -23,7 +24,7 @@ export const useAllDocuments = <T>(limit: number): IUseAllDocuments<T> => {
 
   const updated = useSelector((state: RootState) => state.update.updated);
   const dispatch = useDispatch();
-  const URL_ENDPOINT = import.meta.env.VITE_WORKE_RECORDS_ACTIVE;
+  const URL_ENDPOINT = API_URLS.WORK_RECORDS_ACTIVE;
 
   useEffect(() => {
     const fetchData = async () => {

--- a/src/Hooks/useFilterPersonal/index.ts
+++ b/src/Hooks/useFilterPersonal/index.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import axios from "../../service/httpService";
+import { API_URLS } from "../../service/apiConfig";
 interface PersonalService {
   id: string;
   name: string;
@@ -15,7 +16,7 @@ export const useFilterPersonal = () => {
   const [filterTotalPages, setFilterTotalPages] = useState<number>(1);
   const [filterPage, setFilterPage] = useState<number>(1);
 
-  const URL_ENDPOINT = import.meta.env.VITE_USER_SEARCH;
+  const URL_ENDPOINT = API_URLS.USER_SEARCH;
 
   useEffect(() => {
     const fetchFilteredData = async () => {

--- a/src/Hooks/useFilterProducts/index.ts
+++ b/src/Hooks/useFilterProducts/index.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import axios from "../../service/httpService";
+import { API_URLS } from "../../service/apiConfig";
 
 interface ProductService {
   id: string;
@@ -19,7 +20,7 @@ export const useFilterProducts = () => {
   const [filterPage, setFilterPage] = useState<number>(1);
   const [filterTotalPages, setFilterTotalPages] = useState<number>(1);
 
-  const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS_SEARCH;
+  const URL_ENDPOINT = API_URLS.PRODUCTS_SEARCH;
 
   useEffect(() => {
     const fetchFilteredData = async () => {

--- a/src/Pages/Dashboard/index.tsx
+++ b/src/Pages/Dashboard/index.tsx
@@ -15,6 +15,7 @@ import moment from "moment";
 import axios from "../../service/httpService";
 import { IWorkRecord, IPersonalData } from "../../interface";
 import { Alert } from "@mui/material";
+import { API_URLS } from "../../service/apiConfig";
 
 interface IFormInput {
   startBackup: string;
@@ -80,7 +81,8 @@ export const Dashboard = () => {
   const onSubmit: SubmitHandler<IFormInput> = async (data) => {
     const startBackup = data.startBackup;
     const endBackup = data.endBackup;
-    const URL_ENDPOINT = import.meta.env.VITE_BACKUP;
+    const URL_ENDPOINT = API_URLS.BACKUP;
+
     Swal.fire({
       title: "Generando backup...",
       text: "Por favor espera mientras se genera el archivo.",

--- a/src/Pages/Personal/Update/index.tsx
+++ b/src/Pages/Personal/Update/index.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from "react-redux";
 import Swal from "sweetalert2";
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { API_URLS } from "../../../service/apiConfig";
 
 interface IFormInput {
   name: string;
@@ -29,7 +30,7 @@ export const Update = () => {
     shouldUseNativeValidation: false,
   });
   const { userId } = useParams();
-  const URL_ENDPOINT = import.meta.env.VITE_USER_SEARCH_ID;
+  const URL_ENDPOINT = API_URLS.USER_SEARCH_ID;
   const navigate = useNavigate();
 
   const dispatch = useDispatch();
@@ -65,7 +66,7 @@ export const Update = () => {
   }, [userId, setValue]);
 
   const onSubmit: SubmitHandler<IFormInput> = async (data) => {
-    const URL_ENDPOINT = import.meta.env.VITE_USER_SEARCH_UPDATE;
+    const URL_ENDPOINT = API_URLS.USER_SEARCH_UPDATE;
 
     let haveErrors = false;
     let errorMessages = "";

--- a/src/Pages/Personal/index.tsx
+++ b/src/Pages/Personal/index.tsx
@@ -7,6 +7,7 @@ import Swal from "sweetalert2";
 import { setUpdated } from "../../Store/Slices/updateSlice";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
+import { API_URLS } from "../../service/apiConfig";
 
 interface PersonalData {
   id: string;
@@ -59,7 +60,7 @@ export const Personal = () => {
   };
   const deleteUser = async (user: PersonalData) => {
     const userId = user.id;
-    const URL_ENDPOINT = import.meta.env.VITE_USER_DELETE;
+    const URL_ENDPOINT = API_URLS.USER_DELETE;
     try {
       const result = await Swal.fire({
         title: "¿Estás seguro?",

--- a/src/Pages/Personal/users/index.tsx
+++ b/src/Pages/Personal/users/index.tsx
@@ -9,6 +9,7 @@ import { setUpdated } from "../../../Store/Slices/updateSlice";
 import { useDispatch } from "react-redux";
 import Swal from "sweetalert2";
 import { useNavigate } from "react-router-dom";
+import { API_URLS } from "../../../service/apiConfig";
 
 interface IFormInput {
   name: string;
@@ -30,7 +31,7 @@ export const Users = () => {
   const dispatch = useDispatch();
   const theme = useTheme();
   const onSubmit: SubmitHandler<IFormInput> = async (data) => {
-    const URL_ENDPOINT = import.meta.env.VITE_USER_CREATE;
+    const URL_ENDPOINT = API_URLS.USER_CREATE;
     let haveErrors = false;
     let errorMessages = "";
 

--- a/src/Pages/Products/Create/index.tsx
+++ b/src/Pages/Products/Create/index.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { FormatPrice, ToLowerCase } from "../../../Utils";
 import { setUpdated } from "../../../Store/Slices/updateSlice";
+import { API_URLS } from "../../../service/apiConfig";
 
 interface IFormInput {
   name: string;
@@ -41,7 +42,8 @@ export const Create = () => {
   };
 
   const onSubmit: SubmitHandler<IFormInput> = async (data) => {
-    const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS_CREATE;
+    const URL_ENDPOINT = API_URLS.PRODUCTS_CREATE;
+
     let haveErrors = false;
     let errorMessages = "";
 

--- a/src/Pages/Products/Update/index.tsx
+++ b/src/Pages/Products/Update/index.tsx
@@ -10,6 +10,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { FormatPrice, ToLowerCase } from "../../../Utils";
 import { setUpdated } from "../../../Store/Slices/updateSlice";
+import { API_URLS } from "../../../service/apiConfig";
 
 interface IFormInput {
   id: string;
@@ -94,7 +95,7 @@ export const UpdateProducts = () => {
           price: `${FormatPrice(data.price)} $`,
         };
 
-        const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS_UPDATE;
+        const URL_ENDPOINT = API_URLS.PRODUCTS_UPDATE;
 
         try {
           const response = await axios.put(
@@ -139,7 +140,8 @@ export const UpdateProducts = () => {
     const fetchUserData = async () => {
       try {
         setLoading(true);
-        const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS_SEARCH;
+        const URL_ENDPOINT = API_URLS.PRODUCTS_SEARCH;
+
         const response = await axios.get(`${URL_ENDPOINT}/${productsId}`);
 
         if (response.status >= 200 && response.status < 300) {

--- a/src/Pages/Products/index.tsx
+++ b/src/Pages/Products/index.tsx
@@ -12,6 +12,7 @@ import Swal from "sweetalert2";
 import { useDispatch } from "react-redux";
 import axios from "../../service/httpService";
 import { setUpdated } from "../../Store/Slices/updateSlice";
+import { API_URLS } from "../../service/apiConfig";
 
 interface IProduct {
   id: string;
@@ -84,7 +85,8 @@ export const Products = () => {
   };
   const deleteUser = async (products: IProduct) => {
     const productsId = products.id;
-    const URL_ENDPOINT = import.meta.env.VITE_PRODUCTS_DELETE;
+    const URL_ENDPOINT = API_URLS.PRODUCTS_DELETE;
+
     try {
       const result = await Swal.fire({
         title: "¿Estás seguro?",

--- a/src/service/apiConfig.ts
+++ b/src/service/apiConfig.ts
@@ -1,0 +1,47 @@
+// src/config.js
+
+// Determinamos la URL base según el modo de entorno definido en .env
+const BASE_URL =
+  import.meta.env.VITE_MODE === "production"
+    ? import.meta.env.PRODUCCION_URL
+    : import.meta.env.DEMO_URL;
+
+export const API_URLS = {
+  // Usuarios
+  USER_ALL: `${BASE_URL}/users`,
+  USER_SEARCH: `${BASE_URL}/users/search`,
+  USER_DELETE: `${BASE_URL}/users/delete`,
+  USER_SEARCH_ID: `${BASE_URL}/users/search`,
+  USER_SEARCH_UPDATE: `${BASE_URL}/users/update`,
+  USER_CREATE: `${BASE_URL}/users/create`,
+
+  // Registros de trabajo
+  WORK_RECORDS_ADD_DETAILS: `${BASE_URL}/work-records/add-details`,
+  WORK_RECORDS_ACTIVE: `${BASE_URL}/work-records/active`,
+  WORK_RECORDS_START: `${BASE_URL}/work-records/start-worker-hours`,
+  WORK_RECORDS_END: `${BASE_URL}/work-records/end-worker-hours`,
+  WORK_HOURS_SEARCH_MONTHS: `${BASE_URL}/work-hours/search/months`,
+  WORK_HOURS_ALL_RECORDS: `${BASE_URL}/work-hours/all-record`,
+  WORK_CLOSE_RECORDS: `${BASE_URL}/work-records/close-records`,
+
+  // Productos
+  PRODUCTS_UPDATE: `${BASE_URL}/products/update`,
+  PRODUCTS_UPDATE_COUNT: `${BASE_URL}/products/update/count`,
+  PRODUCTS_SEARCH: `${BASE_URL}/products/search`,
+  PRODUCTS: `${BASE_URL}/products`,
+  PRODUCTS_DELETE: `${BASE_URL}/products/delete`,
+  PRODUCTS_CREATE: `${BASE_URL}/products/create`,
+
+  // Logs globales
+  GLOBAL_LOGS_ALL: `${BASE_URL}/global-logs`,
+  GLOBAL_LOGS_MONTHS: `${BASE_URL}/globalLogs/search/months`,
+
+  // Backup
+  BACKUP: `${BASE_URL}/globalLogs/backup`,
+
+  // Login
+  LOGIN: `${BASE_URL}/admin/login`,
+
+  // Ping
+  PING: `${BASE_URL}/ping`,
+};

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -1,3 +1,4 @@
+import { API_URLS } from "./apiConfig";
 import axios from "./httpService";
 
 interface LoginData {
@@ -7,7 +8,8 @@ interface LoginData {
 }
 
 export const loginUser = async (loginData: LoginData) => {
-  const URL_ENDPOINT = import.meta.env.VITE_LOGIN;
+  const URL_ENDPOINT = API_URLS.LOGIN;
+
   try {
     const response = await axios.post(URL_ENDPOINT, {
       username: loginData.username,


### PR DESCRIPTION
Se agregó una lógica de configuración en el frontend para alternar automáticamente entre entornos de demo y producción mediante VITE_MODE.
Se centralizaron todos los endpoints de la API en el archivo config.js para mejorar la claridad y el mantenimiento.
Se reemplazaron referencias directas a variables de entorno por constantes de API_URLS definidas en config.js.
Esta configuración facilita cambiar entre entornos sin modificar el código en múltiples lugares y asegura que master permanezca limpio.